### PR TITLE
moved webmapper model update code into dst and dst.id null check bloc…

### DIFF
--- a/js/ListView.js
+++ b/js/ListView.js
@@ -456,15 +456,18 @@ function ListView(frame, tables, canvas, model)
                 $('svg, .displayTable tbody tr').off('.drawing');
                 if (dst && dst.id) {
                     $('#container').trigger('map', [src.id, dst.id]);
+
+                    model.maps.add({
+                        'src': model.find_signal(src.id),
+                        'dst': model.find_signal(dst.id),
+                        'key': src.id + '->' + dst.id,
+                        'status': 'staged'
+                    });
                 }
                 // clear table highlights
                 tables.left.highlight_row(null, true);
                 tables.right.highlight_row(null, true);
 
-                model.maps.add({'src': model.find_signal(src.id),
-                                'dst': model.find_signal(dst.id),
-                                'key': src.id + '->' + dst.id,
-                                'status': 'staged'});
                 new_map.remove();
                 new_map = null;
             });


### PR DESCRIPTION
currently if you un-click while making a new map without having a valid destination, a null pointer exception is thrown.